### PR TITLE
Fixes in MinGW builds

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,13 +16,8 @@ class YamlCppConan( ConanFile ):
   }
   default_options = 'shared=False', 'minosx=10.8'
   generators = 'cmake'
-  requires = 'Boost/1.60.0@lasote/stable'
+  requires = "Boost/[>=1.64.0]@conan/stable"
   folder = '%s-%s-%s' % ( name, name, version )
-
-  def configure(self):
-    if self.settings.os == "Windows" and self.settings.compiler == "gcc":
-      self.options["Boost"].without_coroutine = True
-      self.options["Boost"].without_coroutine2 = True
 
   def source( self ):
     zip_name = '%s-%s.tar.gz' % ( self.name, self.version )

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,6 +19,11 @@ class YamlCppConan( ConanFile ):
   requires = 'Boost/1.60.0@lasote/stable'
   folder = '%s-%s-%s' % ( name, name, version )
 
+  def configure(self):
+    if self.settings.os == "Windows" and self.settings.compiler == "gcc":
+      self.options["Boost"].without_coroutine = True
+      self.options["Boost"].without_coroutine2 = True
+
   def source( self ):
     zip_name = '%s-%s.tar.gz' % ( self.name, self.version )
     download( 'https://github.com/jbeder/yaml-cpp/archive/%s' % zip_name, zip_name )
@@ -53,7 +58,7 @@ class YamlCppConan( ConanFile ):
     self.copy( '*yaml-cpp*.a', dst='lib', keep_path=False )
 
   def package_info( self ):
-    if self.settings.os == 'Windows':
+    if self.settings.compiler == "Visual Studio":
       if self.settings.build_type == 'Debug':
         self.cpp_info.libs = [ 'libyaml-cppmdd' ]
       else:

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,12 +1,8 @@
 from conans import ConanFile, CMake
 import os
 
-username = os.getenv( '"CONAN_USERNAME', 'moonforged' )
-channel = os.getenv( 'CONAN_CHANNEL', 'testing' )
-
 class YamlCppTestConan( ConanFile ):
   settings = 'os', 'compiler', 'build_type', 'arch'
-  requires = 'yaml-cpp/0.5.3@%s/%s' %  (username, channel )
   generators = 'cmake'
 
   def build( self ):


### PR DESCRIPTION
For MinGW output library are named as Linux one.

Boost 1.60.0 coroutines do not compile for MinGW  (https://github.com/boostorg/context/issues/16)